### PR TITLE
Add the closest event-target back into the recipeContainer

### DIFF
--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -13,8 +13,6 @@ import {
 import { saveRecipe, deleteRecipe, getRandomUser } from '../src/user-recipes';
 import { getUsers, getRecipes, getIngredients } from './apiCalls';
 import tagData from './data/tags';
-// import { render } from 'sass';
-// import userData from '../sample-data/sample-users';
 
 //Global Variables👇
 let currentRecipeName;
@@ -30,7 +28,6 @@ const individualRecipeContainer = document.querySelector(
 const homeView = document.querySelector('.homepage-view');
 const discoverRecipesHeader = document.querySelector('.discover-header');
 const searchInput = document.getElementById('searchInput');
-// const savedRecipesView = document.querySelector('.saved-recipes-view');
 
 // drop-down-menu & select button DOM querySelector
 const dropDownMenu = document.querySelector('.drop-down-menu');


### PR DESCRIPTION
### Did this break anything?
- [ ] No
- [x]  Yes
### Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [x]  Skip all the other stuff and briefly explain the fix.
### Checklist:
- [ ]  If this code needs to be tested, all tests are passing
- [ ]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing
### Summary:
- File(s) added/changed: domUpdates.js
- Short description of changes:Using event.target.closest('div') on the event listener for recipeContainer.  This fixes the load recipe details from search results, but breaks the saveRecipe to the recipesToCook array.
